### PR TITLE
Feat/async loads dumps operation in codecs

### DIFF
--- a/faust/assignor/client_assignment.py
+++ b/faust/assignor/client_assignment.py
@@ -144,11 +144,9 @@ class ClientAssignment(Record,
         return next(valid_partitions, set())
 
 
-class ClientMetadata(
-    Record,
-    include_metadata=False,
-    namespace='@ClientMetadata'
-):
+class ClientMetadata(Record,
+                     include_metadata=False,
+                     namespace='@ClientMetadata'):
     """Client Metadata data model."""
 
     assignment: ClientAssignment

--- a/faust/assignor/client_assignment.py
+++ b/faust/assignor/client_assignment.py
@@ -1,6 +1,16 @@
 """Client Assignment."""
 import copy
-from typing import List, Mapping, MutableMapping, Sequence, Set, Tuple, cast, Any
+from typing import (
+    List,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    Set,
+    Tuple,
+    cast,
+    Any
+)
+
 from faust.models import Record
 from faust.types import TP
 from faust.types.assignor import HostToPartitionMap

--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -109,7 +109,7 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):
             url=str(self._url),
             changelog_distribution=self.changelog_distribution,
             topic_groups=self._topic_groups,
-        ).dumps()
+        )
 
     @property
     def _url(self) -> URL:
@@ -134,7 +134,7 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):
     def metadata(self, topics: Set[str]) -> ConsumerProtocolMemberMetadata:
         return ConsumerProtocolMemberMetadata(
             self.version, list(topics),
-            self._metadata
+            self._metadata.dumps()
         )
 
     @classmethod

--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -109,7 +109,7 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):
             url=str(self._url),
             changelog_distribution=self.changelog_distribution,
             topic_groups=self._topic_groups,
-        )
+        ).dumps()
 
     @property
     def _url(self) -> URL:
@@ -132,8 +132,10 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):
         assert metadata.url == str(self._url)
 
     def metadata(self, topics: Set[str]) -> ConsumerProtocolMemberMetadata:
-        return ConsumerProtocolMemberMetadata(self.version, list(topics),
-                                              self._metadata.dumps())
+        return ConsumerProtocolMemberMetadata(
+            self.version, list(topics),
+            self._metadata
+        )
 
     @classmethod
     def _group_co_subscribed(cls, topics: Set[str],

--- a/faust/channels.py
+++ b/faust/channels.py
@@ -635,9 +635,11 @@ class SerializedChannel(Channel):
         if key is not None:
             schema = schema or self.schema
             assert schema is not None
-            return await schema.dumps_key(self.app, key,
-                                    serializer=key_serializer,
-                                    headers=headers)
+            return await schema.dumps_key(
+                self.app, key,
+                serializer=key_serializer,
+                headers=headers
+            )
         return None, headers
 
     async def prepare_value(
@@ -650,12 +652,7 @@ class SerializedChannel(Channel):
         schema = schema or self.schema
         assert schema is not None
 
-        # if asyncio.iscoroutine(schema.dumps_value):
         return await schema.dumps_value(
             self.app, value,
             serializer=value_serializer,
             headers=headers)
-
-        # return schema.dumps_value(self.app, value,
-        #                           serializer=value_serializer,
-        #                           headers=headers)

--- a/faust/channels.py
+++ b/faust/channels.py
@@ -246,7 +246,8 @@ class Channel(ChannelT):
             key_serializer: CodecArg = None,
             value_serializer: CodecArg = None,
             callback: MessageSentCallback = None,
-            eager_partitioning: bool = False) -> FutureMessage:
+            eager_partitioning: bool = False,
+            on_table_key_change: Callable = None) -> FutureMessage:
         """Create promise that message will be transmitted."""
         open_headers = self.prepare_headers(headers)
         final_key, open_headers = await self.prepare_key(
@@ -257,6 +258,10 @@ class Channel(ChannelT):
             # Note: raises NotImplementedError if used on unnamed channel.
             partition = self.app.producer.key_partition(
                 self.get_topic_name(), final_key).partition
+
+        if on_table_key_change:
+            on_table_key_change(key, partition)
+
         return FutureMessage(
             PendingMessage(
                 self,

--- a/faust/models/base.py
+++ b/faust/models/base.py
@@ -214,9 +214,11 @@ class Model(ModelT):
         return model.from_data(data) if model else data
 
     @classmethod
-    def loads(cls, s: bytes, *,
-              default_serializer: CodecArg = None,  # XXX use serializer
-              serializer: CodecArg = None) -> ModelT:
+    async def loads(
+        cls, s: bytes, *,
+        default_serializer: CodecArg = None,  # XXX use serializer
+        serializer: CodecArg = None
+    ) -> ModelT:
         """Deserialize model object from bytes.
 
         Keyword Arguments:
@@ -227,7 +229,7 @@ class Model(ModelT):
             warnings.warn(DeprecationWarning(
                 'default_serializer deprecated, use: serializer'))
         ser = cls._options.serializer or serializer or default_serializer
-        data = loads(ser, s)
+        data = await loads(ser, s)
         return cls.from_data(data)
 
     def __init_subclass__(cls,
@@ -459,10 +461,12 @@ class Model(ModelT):
     def _derive(self, *objects: ModelT, **fields: Any) -> ModelT:
         raise NotImplementedError()
 
-    def dumps(self, *, serializer: CodecArg = None) -> bytes:
+    async def dumps(self, *, serializer: CodecArg = None) -> bytes:
         """Serialize object to the target serialization format."""
-        return dumps(serializer or self._options.serializer,
-                     self.to_representation())
+        return await dumps(
+            serializer or self._options.serializer,
+            self.to_representation()
+        )
 
     def __repr__(self) -> str:
         return f'<{type(self).__name__}: {self._humanize()}>'

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -374,9 +374,13 @@ def get_codec(name_or_codec: CodecArg) -> CodecT:
 
 async def dumps(codec: Optional[CodecArg], obj: Any) -> bytes:
     """Encode object into bytes."""
-    return await get_codec(codec).dumps(obj) if codec else obj
+    if codec:
+        return await get_codec(codec).dumps(obj)
+    return obj
 
 
 async def loads(codec: Optional[CodecArg], s: bytes) -> Any:
     """Decode object from bytes."""
-    return await get_codec(codec).loads(s) if codec else s
+    if codec:
+        return await get_codec(codec).loads(s)
+    return s

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -227,7 +227,7 @@ class Codec(CodecT):
         for node in self.nodes:
             codec = cast(Codec, node)
 
-            if asyncio.iscoroutine(codec._dumps):
+            if asyncio.iscoroutinefunction(codec._dumps):
                 obj = await codec._dumps(obj)
             else:
                 obj = codec._dumps(obj)
@@ -240,7 +240,7 @@ class Codec(CodecT):
         for node in reversed(self.nodes):
             codec = cast(Codec, node)
 
-            if asyncio.iscoroutine(codec._loads):
+            if asyncio.iscoroutinefunction(codec._loads):
                 s = await codec._loads(s)
             else:
                 s = codec._loads(s)

--- a/faust/serializers/registry.py
+++ b/faust/serializers/registry.py
@@ -77,11 +77,13 @@ class Registry(RegistryT):
                 return 'raw'
         return serializer
 
-    async def loads_value(self,
-                    typ: Optional[ModelArg],
-                    value: Optional[bytes],
-                    *,
-                    serializer: CodecArg = None) -> Any:
+    async def loads_value(
+        self,
+        typ: Optional[ModelArg],
+        value: Optional[bytes],
+        *,
+        serializer: CodecArg = None
+    ) -> Any:
         """Deserialize value.
 
         Arguments:

--- a/faust/serializers/schemas.py
+++ b/faust/serializers/schemas.py
@@ -85,19 +85,23 @@ class Schema(SchemaT):
             serializer=serializer or self.value_serializer,
         )
 
-    def dumps_key(self, app: AppT, key: K, *,
-                  serializer: CodecArg = None,
-                  headers: OpenHeadersArg) -> Tuple[Any, OpenHeadersArg]:
-        payload = app.serializers.dumps_key(
+    async def dumps_key(
+        self, app: AppT, key: K, *,
+        serializer: CodecArg = None,
+        headers: OpenHeadersArg
+    ) -> Tuple[Any, OpenHeadersArg]:
+        payload = await app.serializers.dumps_key(
             self.key_type, key,
             serializer=serializer or self.key_serializer,
         )
         return payload, self.on_dumps_key_prepare_headers(key, headers)
 
-    def dumps_value(self, app: AppT, value: V, *,
-                    serializer: CodecArg = None,
-                    headers: OpenHeadersArg) -> Tuple[Any, OpenHeadersArg]:
-        payload = app.serializers.dumps_value(
+    async def dumps_value(
+        self, app: AppT, value: V, *,
+        serializer: CodecArg = None,
+        headers: OpenHeadersArg
+    ) -> Tuple[Any, OpenHeadersArg]:
+        payload = await app.serializers.dumps_value(
             self.value_type, value,
             serializer=serializer or self.value_serializer,
         )
@@ -134,7 +138,7 @@ class Schema(SchemaT):
         async def decode(message: Message, *,
                          propagate: bool = default_propagate) -> Any:
             try:
-                k: K = schema_loads_key(app, message, loads=loads_key)
+                k: K = await schema_loads_key(app, message, loads=loads_key)
             except KeyDecodeError as exc:
                 if propagate:
                     raise
@@ -143,7 +147,9 @@ class Schema(SchemaT):
                 try:
                     if message.value is None and allow_empty:
                         return create_event(k, None, message.headers, message)
-                    v: V = schema_loads_value(app, message, loads=loads_value)
+                    v: V = await schema_loads_value(
+                        app, message, loads=loads_value
+                    )
                 except ValueDecodeError as exc:
                     if propagate:
                         raise

--- a/faust/serializers/schemas.py
+++ b/faust/serializers/schemas.py
@@ -75,12 +75,14 @@ class Schema(SchemaT):
             serializer=serializer or self.key_serializer,
         ))
 
-    def loads_value(self, app: AppT, message: Message, *,
-                    loads: Callable = None,
-                    serializer: CodecArg = None) -> VT:
+    async def loads_value(
+        self, app: AppT, message: Message, *,
+        loads: Callable = None,
+        serializer: CodecArg = None
+    ) -> VT:
         if loads is None:
             loads = app.serializers.loads_value
-        return loads(
+        return await loads(
             self.value_type, message.value,
             serializer=serializer or self.value_serializer,
         )

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -254,7 +254,8 @@ class Collection(Service, CollectionT):
                        key: Any,
                        value: Any,
                        key_serializer: CodecArg = None,
-                       value_serializer: CodecArg = None) -> FutureMessage:
+                       value_serializer: CodecArg = None,
+                       on_table_key_change: Callable = None) -> FutureMessage:
         """Send modification event to changelog topic."""
         if key_serializer is None:
             key_serializer = self.key_serializer
@@ -269,6 +270,7 @@ class Collection(Service, CollectionT):
             callback=self._on_changelog_sent,
             # Ensures final partition number is ready in ret.message.partition
             eager_partitioning=True,
+            on_table_key_change=on_table_key_change
         )
 
     def _send_changelog(self,

--- a/faust/tables/table.py
+++ b/faust/tables/table.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar, Type
 
 from mode import Seconds
 
+from functools import partial
+
 from faust import windows
 from faust.types.tables import KT, TableT, VT, WindowWrapperT
 from faust.types.windows import WindowT
@@ -69,21 +71,25 @@ class Table(TableT[KT, VT], Collection):
 
     def on_key_set(self, key: KT, value: VT) -> None:
         """Call when the value for a key in this table is set."""
-        fut = self.send_changelog(self.partition_for_key(key), key, value)
-        # partition may be None, in which case the finalized partition
-        # is in fut.partition
-        partition = fut.message.partition
-        assert partition is not None
-        self._maybe_set_key_ttl(key, partition)
+        self.send_changelog(
+            self.partition_for_key(key),
+            key,
+            value,
+            on_table_key_change=partial(self._maybe_set_key_ttl)
+        )
+
         self._sensor_on_set(self, key, value)
 
     def on_key_del(self, key: KT) -> None:
         """Call when a key in this table is removed."""
-        fut = self.send_changelog(self.partition_for_key(key), key, value=None,
-                                  value_serializer='raw')
-        partition = fut.message.partition
-        assert partition is not None
-        self._maybe_del_key_ttl(key, partition)
+        self.send_changelog(
+            self.partition_for_key(key),
+            key,
+            value=None,
+            value_serializer='raw',
+            on_table_key_change=partial(self._maybe_set_key_ttl)
+        )
+
         self._sensor_on_del(self, key)
 
     def as_ansitable(self, title: str = '{table.name}',

--- a/faust/topics.py
+++ b/faust/topics.py
@@ -204,7 +204,8 @@ class Topic(SerializedChannel, TopicT):
                   value_serializer: CodecArg = None,
                   callback: MessageSentCallback = None,
                   force: bool = False,
-                  eager_partitioning: bool = False) -> FutureMessage:
+                  eager_partitioning: bool = False,
+                  on_table_key_change: Callable = None) -> FutureMessage:
         """Produce message by adding to buffer.
 
         Notes:
@@ -222,7 +223,9 @@ class Topic(SerializedChannel, TopicT):
             value_serializer=value_serializer,
             callback=callback,
             eager_partitioning=eager_partitioning,
+            on_table_key_change=on_table_key_change
         )
+
         self.app.producer.send_soon(fut)
         return fut
 

--- a/faust/topics.py
+++ b/faust/topics.py
@@ -382,7 +382,6 @@ class Topic(SerializedChannel, TopicT):
         """Fulfill promise to publish message to topic."""
         app = self.app
         message: PendingMessage = fut.message
-        print(message, "HOla ")
         topic = self._topic_name_or_default(message.channel)
         key: bytes = cast(bytes, message.key)
         value: bytes = cast(bytes, message.value)

--- a/faust/topics.py
+++ b/faust/topics.py
@@ -382,6 +382,7 @@ class Topic(SerializedChannel, TopicT):
         """Fulfill promise to publish message to topic."""
         app = self.app
         message: PendingMessage = fut.message
+        print(message, "HOla ")
         topic = self._topic_name_or_default(message.channel)
         key: bytes = cast(bytes, message.key)
         value: bytes = cast(bytes, message.value)

--- a/faust/transport/producer.py
+++ b/faust/transport/producer.py
@@ -92,7 +92,8 @@ class ProducerBuffer(Service):
         get_pending = self.pending.get
         send_pending = self._send_pending
         while not self.should_stop:
-            msg = await get_pending()
+            awaitable_msg = await get_pending()
+            msg = await awaitable_msg
             await send_pending(msg)
 
     @property

--- a/faust/web/views.py
+++ b/faust/web/views.py
@@ -272,7 +272,7 @@ def takes_model(Model: Type[ModelT]) -> ViewDecorator:
         async def _inner(view: View, request: Request,
                          *args: Any, **kwargs: Any) -> Response:
             data: bytes = await view.read_request_content(request)
-            obj: ModelT = Model.loads(data, serializer='json')
+            obj: ModelT = await Model.loads(data, serializer='json')
             return await fun(  # type: ignore
                 view, request, obj, *args, **kwargs)
         return _inner

--- a/t/functional/serializers/test_registry.py
+++ b/t/functional/serializers/test_registry.py
@@ -1,5 +1,5 @@
 import typing
-import asyncio
+
 from decimal import Decimal
 
 import faust

--- a/t/functional/test_channels.py
+++ b/t/functional/test_channels.py
@@ -236,10 +236,11 @@ async def test_deliver(*, channel, app):
     assert event.message is msg
 
 
-def test_as_future_message__eager_partitioning(*, app):
+@pytest.mark.asyncio
+async def test_as_future_message__eager_partitioning(*, app):
     topic = app.topic('foo')
     app.producer = Mock(name='producer')
-    fut = topic.as_future_message(
+    fut = await topic.as_future_message(
         key=b'foo',
         value=b'bar',
         partition=None,
@@ -248,10 +249,11 @@ def test_as_future_message__eager_partitioning(*, app):
     assert fut.message.partition is not None
 
 
-def test_as_future_message__eager_partitioning_on_channel(*, channel, app):
+@pytest.mark.asyncio
+async def test_as_future_message__eager_partitioning_on_channel(*, channel, app):
     app.producer = Mock(name='producer')
     with pytest.raises(NotImplementedError):
-        channel.as_future_message(
+        await channel.as_future_message(
             key=b'foo',
             value=b'bar',
             partition=None,

--- a/t/functional/test_channels.py
+++ b/t/functional/test_channels.py
@@ -250,7 +250,9 @@ async def test_as_future_message__eager_partitioning(*, app):
 
 
 @pytest.mark.asyncio
-async def test_as_future_message__eager_partitioning_on_channel(*, channel, app):
+async def test_as_future_message__eager_partitioning_on_channel(
+    *, channel, app
+):
     app.producer = Mock(name='producer')
     with pytest.raises(NotImplementedError):
         await channel.as_future_message(

--- a/t/functional/test_models.py
+++ b/t/functional/test_models.py
@@ -87,7 +87,8 @@ def test_parameters():
         account2.foo
 
 
-def test_paramters_with_custom_init():
+@pytest.mark.asyncio
+async def test_paramters_with_custom_init():
 
     class Point(Record, include_metadata=False):
         x: int
@@ -101,7 +102,7 @@ def test_paramters_with_custom_init():
     assert p.x == 30
     assert p.y == 10
 
-    payload = p.dumps(serializer='json')
+    payload = await p.dumps(serializer='json')
     assert payload == b'{"x": 30, "y": 10}'
 
     data = json.loads(payload)
@@ -110,7 +111,8 @@ def test_paramters_with_custom_init():
     assert p2.y == 10
 
 
-def test_parameters_with_custom_init_and_super():
+@pytest.mark.asyncio
+async def test_parameters_with_custom_init_and_super():
 
     class Point(Record, include_metadata=False):
         x: int
@@ -124,7 +126,7 @@ def test_parameters_with_custom_init_and_super():
     assert p.y == 10
     assert p.z == 40
 
-    payload = p.dumps(serializer='json')
+    payload = await p.dumps(serializer='json')
     assert payload == b'{"x": 30, "y": 10}'
 
     data = json.loads(payload)
@@ -134,7 +136,8 @@ def test_parameters_with_custom_init_and_super():
     assert p2.z == 40
 
 
-def test_datetimes():
+@pytest.mark.asyncio
+async def test_datetimes():
 
     class Date(Record, coerce=True):
         date: datetime
@@ -161,35 +164,72 @@ def test_datetimes():
         dates: Optional[List[datetime]]
 
     n1 = datetime.utcnow()
-    assert Date.loads(Date(date=n1).dumps()).date == n1
-    assert OptionalDate.loads(OptionalDate(date=n1).dumps()).date == n1
-    assert OptionalDate.loads(OptionalDate(date=None).dumps()).date is None
+    result = await Date.loads(
+        await Date(date=n1).dumps()
+    )
+    assert result.date == n1
+
+    result = await OptionalDate.loads(
+        await OptionalDate(date=n1).dumps()
+    )
+    assert result.date == n1
+
+    result = await OptionalDate.loads(await OptionalDate(date=None).dumps())
+    assert result.date is None
+
     n2 = datetime.utcnow()
-    assert ListOfDate.loads(ListOfDate(
-        dates=[n1, n2]).dumps()).dates == [n1, n2]
-    assert OptionalListOfDate.loads(OptionalListOfDate(
-        dates=None).dumps()).dates is None
-    assert OptionalListOfDate.loads(OptionalListOfDate(
-        dates=[n2, n1]).dumps()).dates == [n2, n1]
-    assert OptionalListOfDate2.loads(OptionalListOfDate2(
-        dates=None).dumps()).dates is None
-    assert OptionalListOfDate2.loads(OptionalListOfDate2(
-        dates=[n1, n2]).dumps()).dates == [n1, n2]
-    assert TupleOfDate.loads(TupleOfDate(
-        dates=(n1, n2)).dumps()).dates == (n1, n2)
-    assert TupleOfDate.loads(TupleOfDate(
-        dates=(n2,)).dumps()).dates == (n2,)
-    assert SetOfDate.loads(SetOfDate(
-        dates={n1, n2}).dumps()).dates == {n1, n2}
-    assert MapOfDate.loads(MapOfDate(
-        dates={'A': n1, 'B': n2}).dumps()).dates == {'A': n1, 'B': n2}
+    result = await ListOfDate.loads(
+        await ListOfDate(dates=[n1, n2]).dumps()
+    )
+    assert result.dates == [n1, n2]
+
+    result = await OptionalListOfDate.loads(
+        await OptionalListOfDate(dates=None).dumps()
+    )
+    assert result.dates is None
+
+    result = await OptionalListOfDate.loads(
+        await OptionalListOfDate(dates=[n2, n1]).dumps()
+    )
+    assert result.dates == [n2, n1]
+
+    result = await OptionalListOfDate2.loads(
+        await OptionalListOfDate2(dates=None).dumps()
+    )
+    assert result.dates is None
+
+    result = await OptionalListOfDate2.loads(
+        await OptionalListOfDate2(dates=[n1, n2]).dumps()
+    )
+    assert result.dates == [n1, n2]
+
+    result = await TupleOfDate.loads(
+        await TupleOfDate(dates=(n1, n2)).dumps()
+    )
+    assert result.dates == (n1, n2)
+
+    result = await TupleOfDate.loads(
+        await TupleOfDate(dates=(n2,)).dumps()
+    )
+    assert result.dates == (n2,)
+
+    result = await SetOfDate.loads(
+        await SetOfDate(dates={n1, n2}).dumps()
+    )
+    assert result.dates == {n1, n2}
+
+    result = await MapOfDate.loads(
+        await MapOfDate(dates={'A': n1, 'B': n2}).dumps()
+    )
+    assert result.dates == {'A': n1, 'B': n2}
 
     datelist = ListOfDate(dates=[n1.isoformat(), n2.isoformat()])
     assert isinstance(datelist.dates[0], datetime)
     assert isinstance(datelist.dates[1], datetime)
 
 
-def test_datetimes__isodates_compat():
+@pytest.mark.asyncio
+async def test_datetimes__isodates_compat():
 
     class Date(Record, coerce=False, isodates=True):
         date: datetime
@@ -213,33 +253,63 @@ def test_datetimes__isodates_compat():
         dates: Optional[List[datetime]]
 
     n1 = datetime.utcnow()
-    assert Date.loads(Date(date=n1).dumps()).date == n1
+    result = await Date.loads(
+        await Date(date=n1).dumps()
+    )
+    assert result.date == n1
+
     n2 = datetime.utcnow()
-    assert ListOfDate.loads(ListOfDate(
-        dates=[n1, n2]).dumps()).dates == [n1, n2]
-    assert OptionalListOfDate.loads(OptionalListOfDate(
-        dates=None).dumps()).dates is None
-    assert OptionalListOfDate.loads(OptionalListOfDate(
-        dates=[n2, n1]).dumps()).dates == [n2, n1]
-    assert OptionalListOfDate2.loads(OptionalListOfDate2(
-        dates=None).dumps()).dates is None
-    assert OptionalListOfDate2.loads(OptionalListOfDate2(
-        dates=[n1, n2]).dumps()).dates == [n1, n2]
-    assert TupleOfDate.loads(TupleOfDate(
-        dates=(n1, n2)).dumps()).dates == (n1, n2)
-    assert TupleOfDate.loads(TupleOfDate(
-        dates=(n2,)).dumps()).dates == (n2,)
-    assert SetOfDate.loads(SetOfDate(
-        dates={n1, n2}).dumps()).dates == {n1, n2}
-    assert MapOfDate.loads(MapOfDate(
-        dates={'A': n1, 'B': n2}).dumps()).dates == {'A': n1, 'B': n2}
+
+    result = await ListOfDate.loads(
+        await ListOfDate(dates=[n1, n2]).dumps()
+    )
+    assert result.dates == [n1, n2]
+
+    result = await OptionalListOfDate.loads(
+        await OptionalListOfDate(dates=None).dumps()
+    )
+    assert result.dates is None
+
+    result = await OptionalListOfDate.loads(
+        await OptionalListOfDate(dates=[n2, n1]).dumps())
+    assert result.dates == [n2, n1]
+
+    result = await OptionalListOfDate2.loads(
+        await OptionalListOfDate2(dates=None).dumps())
+    assert result.dates is None
+
+    result = await OptionalListOfDate2.loads(
+        await OptionalListOfDate2(dates=[n1, n2]).dumps()
+    )
+    assert result.dates == [n1, n2]
+
+    result = await TupleOfDate.loads(
+        await TupleOfDate(dates=(n1, n2)).dumps()
+    )
+    assert result.dates == (n1, n2)
+
+    result = await TupleOfDate.loads(
+        await TupleOfDate(dates=(n2,)).dumps()
+    )
+    assert result.dates == (n2,)
+
+    result = await SetOfDate.loads(
+        await SetOfDate(dates={n1, n2}).dumps()
+    )
+    assert result.dates == {n1, n2}
+
+    result = await MapOfDate.loads(
+        await MapOfDate(dates={'A': n1, 'B': n2}).dumps()
+    )
+    assert result.dates == {'A': n1, 'B': n2}
 
     datelist = ListOfDate(dates=[n1.isoformat(), n2.isoformat()])
     assert isinstance(datelist.dates[0], datetime)
     assert isinstance(datelist.dates[1], datetime)
 
 
-def test_decimals():
+@pytest.mark.asyncio
+async def test_decimals():
 
     class IsDecimal(Record, coerce=True, serializer='json'):
         number: Decimal
@@ -263,33 +333,62 @@ def test_decimals():
         numbers: Mapping[str, Decimal]
 
     n1 = Decimal('1.31341324')
-    assert IsDecimal.loads(IsDecimal(number=n1).dumps()).number == n1
+    result = await IsDecimal.loads(await IsDecimal(number=n1).dumps())
+    assert result.number == n1
+
     n2 = Decimal('3.41569')
-    assert ListOfDecimal.loads(ListOfDecimal(
-        numbers=[n1, n2]).dumps()).numbers == [n1, n2]
-    assert OptionalListOfDecimal.loads(OptionalListOfDecimal(
-        numbers=None).dumps()).numbers is None
-    assert OptionalListOfDecimal.loads(OptionalListOfDecimal(
-        numbers=[n2, n1]).dumps()).numbers == [n2, n1]
-    assert OptionalListOfDecimal2.loads(OptionalListOfDecimal2(
-        numbers=None).dumps()).numbers is None
-    assert OptionalListOfDecimal2.loads(OptionalListOfDecimal2(
-        numbers=[n1, n2]).dumps()).numbers == [n1, n2]
-    assert TupleOfDecimal.loads(TupleOfDecimal(
-        numbers=(n1, n2)).dumps()).numbers == (n1, n2)
-    assert TupleOfDecimal.loads(TupleOfDecimal(
-        numbers=(n2,)).dumps()).numbers == (n2,)
-    assert SetOfDecimal.loads(SetOfDecimal(
-        numbers={n1, n2}).dumps()).numbers == {n1, n2}
-    assert MapOfDecimal.loads(MapOfDecimal(
-        numbers={'A': n1, 'B': n2}).dumps()).numbers == {'A': n1, 'B': n2}
+    result = await ListOfDecimal.loads(
+        await ListOfDecimal(numbers=[n1, n2]).dumps()
+    )
+    assert result.numbers == [n1, n2]
+
+    result = await OptionalListOfDecimal.loads(
+        await OptionalListOfDecimal(numbers=None).dumps()
+    )
+    assert result.numbers is None
+
+    result = await OptionalListOfDecimal.loads(
+        await OptionalListOfDecimal(numbers=[n2, n1]).dumps()
+    )
+    assert result.numbers == [n2, n1]
+
+    result = await OptionalListOfDecimal2.loads(
+        await OptionalListOfDecimal2(numbers=None).dumps()
+    )
+    assert result.numbers is None
+
+    result = await OptionalListOfDecimal2.loads(
+        await OptionalListOfDecimal2(numbers=[n1, n2]).dumps()
+    )
+    assert result.numbers == [n1, n2]
+
+    result = await TupleOfDecimal.loads(
+        await TupleOfDecimal(numbers=(n1, n2)).dumps()
+    )
+    assert result.numbers == (n1, n2)
+
+    result = await TupleOfDecimal.loads(
+        await TupleOfDecimal(numbers=(n2,)).dumps()
+    )
+    assert result.numbers == (n2,)
+
+    result = await SetOfDecimal.loads(
+        await SetOfDecimal(numbers={n1, n2}).dumps()
+    )
+    assert result.numbers == {n1, n2}
+
+    result = await MapOfDecimal.loads(
+        await MapOfDecimal(numbers={'A': n1, 'B': n2}).dumps()
+    )
+    assert result.numbers == {'A': n1, 'B': n2}
 
     dlist = ListOfDecimal(numbers=['1.312341', '3.41569'])
     assert isinstance(dlist.numbers[0], Decimal)
     assert isinstance(dlist.numbers[1], Decimal)
 
 
-def test_decimals_compat():
+@pytest.mark.asyncio
+async def test_decimals_compat():
 
     class IsDecimal(Record, coerce=False, decimals=True, serializer='json'):
         number: Decimal
@@ -331,33 +430,64 @@ def test_decimals_compat():
         numbers: Mapping[str, Decimal]
 
     n1 = Decimal('1.31341324')
-    assert IsDecimal.loads(IsDecimal(number=n1).dumps()).number == n1
+    retult = await IsDecimal.loads(
+        await IsDecimal(number=n1).dumps()
+    )
+    assert retult.number == n1
+
     n2 = Decimal('3.41569')
-    assert ListOfDecimal.loads(ListOfDecimal(
-        numbers=[n1, n2]).dumps()).numbers == [n1, n2]
-    assert OptionalListOfDecimal.loads(OptionalListOfDecimal(
-        numbers=None).dumps()).numbers is None
-    assert OptionalListOfDecimal.loads(OptionalListOfDecimal(
-        numbers=[n2, n1]).dumps()).numbers == [n2, n1]
-    assert OptionalListOfDecimal2.loads(OptionalListOfDecimal2(
-        numbers=None).dumps()).numbers is None
-    assert OptionalListOfDecimal2.loads(OptionalListOfDecimal2(
-        numbers=[n1, n2]).dumps()).numbers == [n1, n2]
-    assert TupleOfDecimal.loads(TupleOfDecimal(
-        numbers=(n1, n2)).dumps()).numbers == (n1, n2)
-    assert TupleOfDecimal.loads(TupleOfDecimal(
-        numbers=(n2,)).dumps()).numbers == (n2,)
-    assert SetOfDecimal.loads(SetOfDecimal(
-        numbers={n1, n2}).dumps()).numbers == {n1, n2}
-    assert MapOfDecimal.loads(MapOfDecimal(
-        numbers={'A': n1, 'B': n2}).dumps()).numbers == {'A': n1, 'B': n2}
+    result = await ListOfDecimal.loads(
+        await ListOfDecimal(numbers=[n1, n2]).dumps()
+    )
+    assert result.numbers == [n1, n2]
+
+    result = await OptionalListOfDecimal.loads(
+        await OptionalListOfDecimal(numbers=None).dumps()
+    )
+    assert result.numbers is None
+
+    result = await OptionalListOfDecimal.loads(
+        await OptionalListOfDecimal(numbers=[n2, n1]).dumps()
+    )
+    assert result.numbers == [n2, n1]
+
+    result = await OptionalListOfDecimal2.loads(
+        await OptionalListOfDecimal2(numbers=None).dumps()
+    )
+    assert result.numbers is None
+
+    result = await OptionalListOfDecimal2.loads(
+        await OptionalListOfDecimal2(numbers=[n1, n2]).dumps()
+    )
+    assert result.numbers == [n1, n2]
+
+    result = await TupleOfDecimal.loads(
+        await TupleOfDecimal(numbers=(n1, n2)).dumps()
+    )
+    assert result.numbers == (n1, n2)
+
+    result = await TupleOfDecimal.loads(
+        await TupleOfDecimal(numbers=(n2,)).dumps()
+    )
+    assert result.numbers == (n2,)
+
+    result = await SetOfDecimal.loads(
+        await SetOfDecimal(numbers={n1, n2}).dumps()
+    )
+    assert result.numbers == {n1, n2}
+
+    result = await MapOfDecimal.loads(
+        await MapOfDecimal(numbers={'A': n1, 'B': n2}).dumps()
+    )
+    assert result.numbers == {'A': n1, 'B': n2}
 
     dlist = ListOfDecimal(numbers=['1.312341', '3.41569'])
     assert isinstance(dlist.numbers[0], Decimal)
     assert isinstance(dlist.numbers[1], Decimal)
 
 
-def test_custom_coercion():
+@pytest.mark.asyncio
+async def test_custom_coercion():
 
     class Foo:
 
@@ -404,26 +534,56 @@ def test_custom_coercion():
         foos: Mapping[str, Foo]
 
     n1 = Foo(101)
-    assert IsFoo.loads(IsFoo(foo=n1).dumps()).foo == n1
+    result = await IsFoo.loads(
+        await IsFoo(foo=n1).dumps()
+    )
+    assert result.foo == n1
+
     n2 = Foo(202)
-    assert ListOfFoo.loads(ListOfFoo(
-        foos=[n1, n2]).dumps()).foos == [n1, n2]
-    assert OptionalListOfFoo.loads(OptionalListOfFoo(
-        foos=None).dumps()).foos is None
-    assert OptionalListOfFoo.loads(OptionalListOfFoo(
-        foos=[n2, n1]).dumps()).foos == [n2, n1]
-    assert OptionalListOfFoo2.loads(OptionalListOfFoo2(
-        foos=None).dumps()).foos is None
-    assert OptionalListOfFoo2.loads(OptionalListOfFoo2(
-        foos=[n1, n2]).dumps()).foos == [n1, n2]
-    assert TupleOfFoo.loads(TupleOfFoo(
-        foos=(n1, n2)).dumps()).foos == (n1, n2)
-    assert TupleOfFoo.loads(TupleOfFoo(
-        foos=(n2,)).dumps()).foos == (n2,)
-    assert SetOfFoo.loads(SetOfFoo(
-        foos={n1, n2}).dumps()).foos == {n1, n2}
-    assert MapOfFoo.loads(MapOfFoo(
-        foos={'A': n1, 'B': n2}).dumps()).foos == {'A': n1, 'B': n2}
+    result = await ListOfFoo.loads(
+        await ListOfFoo(foos=[n1, n2]).dumps()
+    )
+    assert result.foos == [n1, n2]
+
+    result = await OptionalListOfFoo.loads(
+        await OptionalListOfFoo(foos=None).dumps()
+    )
+    assert result.foos is None
+
+    result = await OptionalListOfFoo.loads(
+        await OptionalListOfFoo(foos=[n2, n1]).dumps()
+    )
+    assert result.foos == [n2, n1]
+
+    result = await OptionalListOfFoo2.loads(
+        await OptionalListOfFoo2(foos=None).dumps()
+    )
+    assert result.foos is None
+
+    result = await OptionalListOfFoo2.loads(
+        await OptionalListOfFoo2(foos=[n1, n2]).dumps()
+    )
+    assert result.foos == [n1, n2]
+
+    result = await TupleOfFoo.loads(
+        await TupleOfFoo(foos=(n1, n2)).dumps()
+    )
+    assert result.foos == (n1, n2)
+
+    result = await TupleOfFoo.loads(
+        await TupleOfFoo(foos=(n2,)).dumps()
+    )
+    assert result.foos == (n2,)
+
+    result = await SetOfFoo.loads(
+        await SetOfFoo(foos={n1, n2}).dumps()
+    )
+    assert result.foos == {n1, n2}
+
+    result = await MapOfFoo.loads(
+        await MapOfFoo(foos={'A': n1, 'B': n2}).dumps()
+    )
+    assert result.foos == {'A': n1, 'B': n2}
 
 
 def test_constructor():
@@ -440,39 +600,58 @@ def test_constructor():
     assert not Account(id='123', name='foo', active=False).active
 
 
-def test_submodels():
+@pytest.mark.asyncio
+async def test_submodels():
     a1 = Account(id='123', name='foo', active=True)
     a2 = Account(id='456', name='bar', active=False)
     a3 = Account(id='789', name='baz', active=True)
 
-    assert AccountList.loads(AccountList(
-        accounts=[a1, a2, a3]).dumps()).accounts == [a1, a2, a3]
+    result = await AccountList.loads(
+        await AccountList(accounts=[a1, a2, a3]).dumps()
+    )
+    assert result.accounts == [a1, a2, a3]
 
     expected_set = {a1, a2, a3}
-    acc1 = AccountSet.loads(AccountSet(accounts={a1, a2, a3}).dumps()).accounts
+    result = await AccountSet.loads(
+        await AccountSet(accounts={a1, a2, a3}).dumps()
+    )
+    acc1 = result.accounts
     assert isinstance(acc1, set)
     assert len(acc1) == len(expected_set)
     for acc in acc1:
         assert acc in expected_set
-    assert AccountMap.loads(AccountMap(
-        accounts={'a': a1, 'b': a2, 'c': a3}).dumps()).accounts == {
+
+    result = await AccountMap.loads(
+        await AccountMap(accounts={'a': a1, 'b': a2, 'c': a3}).dumps()
+    )
+    assert result.accounts == {
         'a': a1,
         'b': a2,
         'c': a3,
     }
 
 
-def test_submodels_forward_reference():
+@pytest.mark.asyncio
+async def test_submodels_forward_reference():
     a1 = Account(id='123', name='foo', active=True)
     a2 = Account(id='456', name='bar', active=False)
     a3 = Account(id='789', name='baz', active=True)
 
-    assert AccountList.loads(FREFAccountList(
-        accounts=[a1, a2, a3]).dumps()).accounts == [a1, a2, a3]
-    assert sorted(AccountSet.loads(FREFAccountSet(
-        accounts={a1, a2, a3}).dumps()).accounts) == sorted({a1, a2, a3})
-    assert AccountMap.loads(FREFAccountMap(
-        accounts={'a': a1, 'b': a2, 'c': a3}).dumps()).accounts == {
+    result = await AccountList.loads(
+        await FREFAccountList(accounts=[a1, a2, a3]).dumps()
+    )
+    assert result.accounts == [a1, a2, a3]
+
+    result = await AccountSet.loads(
+        await FREFAccountSet(accounts={a1, a2, a3}).dumps()
+    )
+
+    assert sorted(result.accounts) == sorted({a1, a2, a3})
+
+    result = await AccountMap.loads(
+        await FREFAccountMap(accounts={'a': a1, 'b': a2, 'c': a3}).dumps()
+    )
+    assert result.accounts == {
         'a': a1,
         'b': a2,
         'c': a3,
@@ -592,6 +771,7 @@ class test_FieldDescriptor:
         assert User.account.name.getattr(u) == 4
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('record', [
     Account(id=None, name=None),
     Account(id='123', name='123'),
@@ -604,8 +784,8 @@ class test_FieldDescriptor:
     AccountList(accounts=[Account(id=None, name=None)]),
     AccountMap(accounts={'foo': Account(id=None, name='foo')}),
 ])
-def test_dumps(record):
-    assert record.loads(record.dumps()) == record
+async def test_dumps(record):
+    assert await record.loads(await record.dumps()) == record
     assert repr(record)
 
 
@@ -716,7 +896,8 @@ def test_supports_post_init():
     assert x.z == 4
 
 
-def test_default_no_blessed_key():
+@pytest.mark.asyncio
+async def test_default_no_blessed_key():
 
     class X(Record):
         a: int
@@ -730,12 +911,13 @@ def test_default_no_blessed_key():
     x = LooksLikeX(303)
     y = Y(x)
 
-    data = Y.dumps(y, serializer='json')
-    y2 = Y.loads(data, serializer='json')
+    data = await Y.dumps(y, serializer='json')
+    y2 = await Y.loads(data, serializer='json')
     assert isinstance(y2.x, X)
 
 
-def test_default_multiple_levels_no_blessed_key():
+@pytest.mark.asyncio
+async def test_default_multiple_levels_no_blessed_key():
 
     class StdAttribution(Record):
         first_name: str
@@ -755,12 +937,13 @@ def test_default_multiple_levels_no_blessed_key():
         last_name='Costanza',
         address=Address('US'),
     ))
-    s = event.loads(event.dumps(serializer='json'), serializer='json')
+    s = await event.loads(await event.dumps(serializer='json'), serializer='json')
     assert isinstance(s.account, Account)
     assert isinstance(s.account.address, Address)
 
 
-def test_polymorphic_fields(app):
+@pytest.mark.asyncio
+async def test_polymorphic_fields(app):
 
     class X(Record):
         a: int
@@ -774,12 +957,13 @@ def test_polymorphic_fields(app):
     x = LooksLikeX(303)
     y = Y(x)
 
-    data = Y.dumps(y, serializer='json')
-    y2 = app.serializers.loads_key(Y, data, serializer='json')
+    data = await Y.dumps(y, serializer='json')
+    y2 = await app.serializers.loads_key(Y, data, serializer='json')
     assert isinstance(y2.x, LooksLikeX)
 
 
-def test_compat_enabled_blessed_key(app):
+@pytest.mark.asyncio
+async def test_compat_enabled_blessed_key(app):
 
     class X(Record):
         a: int
@@ -793,12 +977,13 @@ def test_compat_enabled_blessed_key(app):
     x = LooksLikeX(303)
     y = Y(x)
 
-    data = Y.dumps(y, serializer='json')
-    y2 = app.serializers.loads_key(Y, data, serializer='json')
+    data = await Y.dumps(y, serializer='json')
+    y2 = await app.serializers.loads_key(Y, data, serializer='json')
     assert isinstance(y2.x, LooksLikeX)
 
 
-def test__polymorphic_fields_deeply_nested():
+@pytest.mark.asyncio
+async def test__polymorphic_fields_deeply_nested():
 
     class BaseAttribution(Record, abc.ABC):
 
@@ -821,7 +1006,7 @@ def test__polymorphic_fields_deeply_nested():
         event='bar',
         data=AdjustData('baz'),
     ))
-    value = x.dumps(serializer='json')
+    value = await x.dumps(serializer='json')
     value_dict = json.loads(value)
     value_dict['event']['__faust']['ns'] = 'x.y.z'
     model = AdjustRecord.from_data(value_dict)
@@ -829,7 +1014,8 @@ def test__polymorphic_fields_deeply_nested():
     assert isinstance(model.event.data, AdjustData)
 
 
-def test_compat_blessed_key_deeply_nested():
+@pytest.mark.asyncio
+async def test_compat_blessed_key_deeply_nested():
 
     class BaseAttribution(Record, abc.ABC):
 
@@ -852,7 +1038,7 @@ def test_compat_blessed_key_deeply_nested():
         event='bar',
         data=AdjustData('baz'),
     ))
-    value = x.dumps(serializer='json')
+    value = await x.dumps(serializer='json')
     value_dict = json.loads(value)
     value_dict['event']['__faust']['ns'] = 'x.y.z'
     model = AdjustRecord.from_data(value_dict)
@@ -1025,7 +1211,8 @@ def test_parse_iso8601(input, expected):
         iso8601.parse, datetime, input) == expected
 
 
-def test_list_field_refers_to_self():
+@pytest.mark.asyncio
+async def test_list_field_refers_to_self():
 
     class X(Record):
         id: int
@@ -1033,15 +1220,16 @@ def test_list_field_refers_to_self():
 
     x = X(1, [X(2, [X(3, [])])])
 
-    as_json = x.dumps(serializer='json')
-    loads = X.loads(as_json, serializer='json')
+    as_json = await x.dumps(serializer='json')
+    loads = await X.loads(as_json, serializer='json')
     assert loads == x
 
     assert isinstance(loads.xs[0], X)
     assert isinstance(loads.xs[0].xs[0], X)
 
 
-def test_optional_modelfield():
+@pytest.mark.asyncio
+async def test_optional_modelfield():
 
     class X(Record):
         id: int
@@ -1051,8 +1239,8 @@ def test_optional_modelfield():
 
     y = Y(X(30))
 
-    as_json = y.dumps(serializer='json')
-    loads = Y.loads(as_json, serializer='json')
+    as_json = await y.dumps(serializer='json')
+    loads = await Y.loads(as_json, serializer='json')
     assert loads == y
 
     assert isinstance(loads.x, X)
@@ -1115,13 +1303,14 @@ def test_maybe_namespace_raises_for_missing_abstract_type():
                            preferred_type=ModelT)
 
 
-def test_compat_loads_DeprecationWarning():
+@pytest.mark.asyncio
+async def test_compat_loads_DeprecationWarning():
     class X(Record):
         foo: str
 
-    payload = X('foo').dumps(serializer='json')
+    payload = await X('foo').dumps(serializer='json')
     with pytest.warns(DeprecationWarning):
-        X.loads(payload, default_serializer='json')
+        await X.loads(payload, default_serializer='json')
 
 
 def test_model_overriding_Options_sets_options():
@@ -1187,7 +1376,8 @@ def test_Record_comparison():
         object() <= X(10)
 
 
-def test_maybe_model():
+@pytest.mark.asyncio
+async def test_maybe_model():
 
     class X(Record):
         x: int
@@ -1198,7 +1388,7 @@ def test_maybe_model():
     assert maybe_model(1.01) == 1.01
 
     x1 = X(10, 20)
-    assert maybe_model(json.loads(x1.dumps(serializer='json'))) == x1
+    assert maybe_model(json.loads(await x1.dumps(serializer='json'))) == x1
 
 
 def test_StringField():

--- a/t/functional/test_models.py
+++ b/t/functional/test_models.py
@@ -937,7 +937,8 @@ async def test_default_multiple_levels_no_blessed_key():
         last_name='Costanza',
         address=Address('US'),
     ))
-    s = await event.loads(await event.dumps(serializer='json'), serializer='json')
+    s = await event.loads(
+        await event.dumps(serializer='json'), serializer='json')
     assert isinstance(s.account, Account)
     assert isinstance(s.account.address, Address)
 

--- a/t/functional/web/test_views.py
+++ b/t/functional/web/test_views.py
@@ -46,7 +46,9 @@ def inject_blueprint(app):
 async def test_takes_model(*, inject_blueprint, web_client, app):
     client = await web_client
     obj = XModel(aint=30, astr='hello')
-    resp = await client.post('/test/takes/', data=obj.dumps(serializer='json'))
+    data = await obj.dumps(serializer='json')
+    resp = await client.post(
+        '/test/takes/', data=data)
     assert resp.status == 200
     payload = await resp.json()
     assert XModel.from_data(payload) == obj

--- a/t/unit/app/test_base.py
+++ b/t/unit/app/test_base.py
@@ -78,15 +78,15 @@ async def test_send(
             # (note that a bytes key will be left alone.
             key_serializer = 'raw'
         if isinstance(key, ModelT):
-            expected_key = key.dumps(serializer='raw')
+            expected_key = await key.dumps(serializer='raw')
         elif key_serializer:
-            expected_key = codecs.dumps(key_serializer, key)
+            expected_key = await codecs.dumps(key_serializer, key)
         else:
             expected_key = want_bytes(key)
     else:
         expected_key = None
     expected_sender.assert_called_with(
-        expected_topic, expected_key, event.dumps(),
+        expected_topic, expected_key, await event.dumps(),
         partition=None,
         timestamp=None,
         headers={},

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -5,6 +5,8 @@ from faust.transport.producer import Producer
 from faust.utils.tracing import set_current_span
 from mode.utils.mocks import AsyncMock, Mock
 
+from faust.types import FutureMessage, PendingMessage
+
 
 @pytest.fixture()
 def app(event_loop, request):
@@ -32,3 +34,25 @@ def app(event_loop, request):
 @pytest.fixture()
 def web(app):
     return app.web
+
+
+@pytest.fixture()
+def future_message():
+    def future(topic):
+        callback = Mock(name='callback')
+        headers = {'k': 'v'}
+        return FutureMessage(
+            PendingMessage(
+                topic,
+                key='foo',
+                value='bar',
+                partition=130,
+                timestamp=312.5134,
+                headers=headers,
+                key_serializer='json',
+                value_serializer='json',
+                callback=callback,
+            )
+        )
+
+    return future

--- a/t/unit/serializers/test_codecs.py
+++ b/t/unit/serializers/test_codecs.py
@@ -12,31 +12,35 @@ import pytest
 DATA = {'a': 1, 'b': 'string'}
 
 
-def test_interface():
+@pytest.mark.asyncio
+async def test_interface():
     s = Codec()
     with pytest.raises(NotImplementedError):
-        s._loads(b'foo')
+        await s._loads(b'foo')
     with pytest.raises(NotImplementedError):
-        s.dumps(10)
+        await s.dumps(10)
     assert s.__or__(1) is NotImplemented
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('codec', ['json', 'pickle', 'yaml'])
-def test_json_subset(codec: str) -> None:
-    assert loads(codec, dumps(codec, DATA)) == DATA
+async def test_json_subset(codec: str) -> None:
+    assert await loads(codec, await dumps(codec, DATA)) == DATA
 
 
+@pytest.mark.asyncio
 @given(binary())
-def test_binary(input: bytes) -> None:
-    assert loads('binary', dumps('binary', input)) == input
+async def test_binary(input: bytes) -> None:
+    assert await loads('binary', await dumps('binary', input)) == input
 
 
+@pytest.mark.asyncio
 @given(dictionaries(text(), text()))
-def test_combinators(input: Mapping[str, str]) -> None:
+async def test_combinators(input: Mapping[str, str]) -> None:
     s = json() | _binary()
     assert repr(s).replace("u'", "'") == 'json() | binary()'
 
-    d = s.dumps(input)
+    d = await s.dumps(input)
     assert isinstance(d, bytes)
     assert _json.loads(want_str(base64.b64decode(d))) == input
 
@@ -56,7 +60,8 @@ def test_register():
         codecs.pop('mine')
 
 
-def test_raw():
-    bits = get_codec('raw').dumps('foo')
+@pytest.mark.asyncio
+async def test_raw():
+    bits = await get_codec('raw').dumps('foo')
     assert isinstance(bits, bytes)
-    assert get_codec('raw').loads(bits) == b'foo'
+    assert await get_codec('raw').loads(bits) == b'foo'

--- a/t/unit/tables/test_base.py
+++ b/t/unit/tables/test_base.py
@@ -127,6 +127,7 @@ class test_Collection:
             value_serializer='json',
             callback=table._on_changelog_sent,
             eager_partitioning=True,
+            on_table_key_change=None
         )
 
     def test_send_changelog__custom_serializers(self, *, table):
@@ -135,7 +136,7 @@ class test_Collection:
         table._send_changelog(
             event, 'k', 'v',
             key_serializer='raw',
-            value_serializer='raw',
+            value_serializer='raw'
         )
         table.changelog_topic.send_soon.assert_called_once_with(
             key='k',
@@ -145,6 +146,7 @@ class test_Collection:
             value_serializer='raw',
             callback=table._on_changelog_sent,
             eager_partitioning=True,
+            on_table_key_change=None
         )
 
     def test_send_changelog__no_current_event(self, *, table):

--- a/t/unit/test_topics.py
+++ b/t/unit/test_topics.py
@@ -338,7 +338,7 @@ class test_Topic:
         topic = topic.derive_topic(value_serializer='json', value_type=Dummy)
         topic.on_value_decode_error = AsyncMock()
         topic._compile_decode()
-        print(topic.__dict__, topic.__class__)
+
         await topic.decode(message_empty_value, propagate=False)
         topic.on_value_decode_error.assert_called_once()
 

--- a/t/unit/test_topics.py
+++ b/t/unit/test_topics.py
@@ -133,7 +133,7 @@ class test_Topic:
         topic._get_producer = AsyncMock(return_value=producer)
         callback = Mock(name='callback')
         headers = {'k': 'v'}
-        fm = topic.as_future_message(
+        fm = await topic.as_future_message(
             key='foo',
             value='bar',
             partition=130,
@@ -144,8 +144,9 @@ class test_Topic:
             callback=callback,
         )
         await topic.publish_message(fm, wait=True)
-        key, headers = topic.prepare_key('foo', 'json', None, headers)
-        value, headers = topic.prepare_value('bar', 'json', None, headers)
+        key, headers = await topic.prepare_key('foo', 'json', None, headers)
+        value, headers = await topic.prepare_value(
+            'bar', 'json', None, headers)
         producer.send_and_wait.coro.assert_called_once_with(
             topic.get_topic_name(),
             key,
@@ -337,6 +338,7 @@ class test_Topic:
         topic = topic.derive_topic(value_serializer='json', value_type=Dummy)
         topic.on_value_decode_error = AsyncMock()
         topic._compile_decode()
+        print(topic.__dict__, topic.__class__)
         await topic.decode(message_empty_value, propagate=False)
         topic.on_value_decode_error.assert_called_once()
 

--- a/t/unit/transport/test_producer.py
+++ b/t/unit/transport/test_producer.py
@@ -1,5 +1,5 @@
 import pytest
-from mode.utils.mocks import AsyncMock, Mock, call
+from mode.utils.mocks import AsyncMock, Mock
 from faust.transport.producer import Producer, ProducerBuffer
 
 
@@ -32,22 +32,25 @@ class test_ProducerBuffer:
         )
 
     @pytest.mark.asyncio
-    async def test__handle_pending(self, *, buf):
-        buf.pending = Mock(get=AsyncMock())
-        buf._send_pending = AsyncMock()
+    async def test__handle_pending(self, *, buf, app, future_message):
+        message = future_message(app.topic('foo'))
+
+        async def get_pending():
+            async def async_func():
+                return message
+            return async_func()
 
         async def on_send(fut):
             if buf._send_pending.call_count >= 3:
                 buf._stopped.set()
 
+        buf.pending.get = get_pending
+        buf._send_pending = AsyncMock()
+
         buf._send_pending.side_effect = on_send
 
         await buf._handle_pending(buf)
-
-        buf._send_pending.assert_has_calls([
-            call(buf.pending.get.coro.return_value),
-            call(buf.pending.get.coro.return_value),
-        ])
+        buf._send_pending.assert_called_with(message)
 
     @pytest.mark.asyncio
     async def test_wait_until_ebb(self, *, buf):


### PR DESCRIPTION
A WIP to allow async operation in codecs. Still is missing how to handle asyn operation for tables.

* Allow async operation on codecs `(_loads and _dumps)`
* Codecs works with `sync` or `async` `loads` & `dumps`
* Test fixed
* WIP async storage (tables)

PD: This PR will introduce a braking change.